### PR TITLE
LWRP to Manage Rich Rules in firewalld

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,3 +13,8 @@ suites:
     run_list:
       - "recipe[fixture::default]"
     attributes:
+
+  - name: rich_rule
+    run_list:
+      - "recipe[fixture::rich_rule]"
+    attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## %%version%% (unreleased)
+## version (unreleased)
 
 ### New
 
@@ -22,7 +22,7 @@
 
 * Add missing defaults in resource file and clean up comment. [Manny Toledo]
 
-## %%0.2.1%%
+## 0.2.1
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+## %%version%% (unreleased)
+
+### New
+
+* Version bump in metadata. [Manny Toledo]
+
+* Add Rich Rule LWRP documentation to README. [Manny Toledo]
+
+* ChefSpec test added for Rich Rule LWRP. [Manny Toledo]
+
+* Integration tests added for Rich Rule LWRP. [Manny Toledo]
+
+* Add rules directly with Rich Rule LWRP! [Manny Toledo]
+
+### Fix
+
+* Correct IPs in tests to more common ranges. [Manny Toledo]
+
+* Update readme. [Manny Toledo]
+
+* Add missing defaults in resource file and clean up comment. [Manny Toledo]
+
+## %%0.2.1%%
+
+### New
+
+* Better README and send email for Travis. [Jeff Hutchison]
+
+* Update ruby version. [Jeff Hutchison]
+
+* Add chefspec custom matchers, other cleanup. [Jeff Hutchison]
+
+* Need berkshelf for chefspec tests in Travis. [Jeff Hutchison]
+
+* Add chefspec tests. [Jeff Hutchison]
+
+* Exclude dependencies not used by Travis. [Jeff Hutchison]
+
+* Enable Travis CI. [Jeff Hutchison]
+
+* Clean up syntax. [Jeff Hutchison]
+
+* Use bundler. [Jeff Hutchison]
+
+* Add more tests. [Jeff Hutchison]
+
+* Removed attributes not recognized by Berkshelf. [Jeff Hutchison]
+
+* Add issues url. [Jeff Hutchison]
+
+* Bump version. [Jeff Hutchison]
+
+* Update README. [Jeff Hutchison]
+
+* Update license to Apache v2. [Jeff Hutchison]
+
+* First version with tests. [Jeff Hutchison]
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### New
 
-* Version bump in metadata. [Manny Toledo]
-
 * Add Rich Rule LWRP documentation to README. [Manny Toledo]
 
 * ChefSpec test added for Rich Rule LWRP. [Manny Toledo]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Contributing
 License & Authors
 -----------------
 - Author:: Jeff Hutchison <jeff@jeffhutchison.com>
+- Author:: Manuel Toledo   <mtoledo@adobe.com>
 
 ```text
 Copyright 2015, Jeff Hutchison

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ firewalld LWRP
 [![Build Status](https://travis-ci.org/jhh/firewalld-cookbook.svg?branch=master)](https://travis-ci.org/jhh/firewalld-cookbook)
 [![Code Climate](https://codeclimate.com/github/jhh/firewalld-cookbook/badges/gpa.svg)](https://codeclimate.com/github/jhh/firewalld-cookbook)
 
-`firewalld` provides a LWRP for adding and removing ports and rules to your firewall.
+`firewalld` provides a LWRP for adding and removing ports to your firewall.
 
 Attributes
 ----------
@@ -28,9 +28,8 @@ Attributes
 	</tr>
 </table>
 
-Resource Overview
------------------
-### port
+Actions
+-------
 
 Default action adds a port to the firewall:
 
@@ -59,68 +58,6 @@ firewalld_port '993/tcp' do
 	zone   'public'
 end
 ```
-
-### rich_rule
-
-The `rich_rule` allows you to create complex rules directly onto the firewall.
-It will load the rule into the running config and pass it to firewalld with the
-`--permanent` flag, to persist it after a reload.
-
-#### Examples
-
-```ruby
-# This opens the ssh service to ip `192.168.100.5` and logs at a rate of 1 entry
-# per minute with a prefix of ssh on each log entry.
-#
-
-firewalld_rich_rule "ssh_add" do
-  zone 'public'
-  family 'ipv4'
-  source_address '192.168.100.5/32'
-  service_name 'ssh'
-  log_prefix 'ssh'
-  log_level 'info'
-  limit_value '1/m'
-  firewall_action 'accept'
-  action :add
-end
-```
-
-#### Parameters
-The parameters for `rich_resource` map  directly to their commandline flag.
-More can be read here: [Complex Firewall Rules with Rich Language](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_Firewalls.html#Configuring_Complex_Firewall_Rules_with_the_Rich-Language_Syntax)
-
-- `name` - The name of the resource. This is not passed to the `firewall-cmd`.
-
-- `service-name` - Name of the service defined by `firewalld-cmd --get-services`.
-
-- `family` - IPv family. Choice of 'ipv4' or 'ipv6'. Default: 'ipv4'
-
-- `zone` - Predefined zone into which a network interface is placed.
-
-- `source_address` - Limits the origin of a connection attempt to a specific 
-  range of IPs.
-
-- `destination_address` - Limits the target of a connection attempt to a
-  specific range of IPs.
-
-- `port_number` - Can be a single integer or a port range, for example `5060-5062`.
-  The protocol can be specified. Depends on `port_protocol` parameter.
-
-- `port_protocol` - The protocol for the specified port, can be 'tcp' or 'udp'. 
-  Depends on `port_number` parameter and defaults to 'tcp'.
-
-- `log_prefix` - Logs new connection attempts with kernel logging. This will 
-  prepend the log lines with this prefix.
-
-- `log_level` - Can be one of 'emerg', 'alert', 'error', 'warning', 'notice', 
-  'info', or 'debug'.
-
-- `limit_value` - Limits the rate at which logs are written. Defaults to "1/m" 
-  one write per minute.
-
-- `firewall_action` - Can be one of 'accept', 'reject', or 'drop'. This is the 
-  behavior by which all traffic that matches the rule will be handled.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ firewalld LWRP
 [![Build Status](https://travis-ci.org/jhh/firewalld-cookbook.svg?branch=master)](https://travis-ci.org/jhh/firewalld-cookbook)
 [![Code Climate](https://codeclimate.com/github/jhh/firewalld-cookbook/badges/gpa.svg)](https://codeclimate.com/github/jhh/firewalld-cookbook)
 
-`firewalld` provides a LWRP for adding and removing ports to your firewall.
+`firewalld` provides a LWRP for adding and removing ports and rules to your firewall.
 
 Attributes
 ----------
@@ -28,8 +28,9 @@ Attributes
 	</tr>
 </table>
 
-Actions
--------
+Resource Overview
+-----------------
+### port
 
 Default action adds a port to the firewall:
 
@@ -58,6 +59,68 @@ firewalld_port '993/tcp' do
 	zone   'public'
 end
 ```
+
+### rich_rule
+
+The `rich_rule` allows you to create complex rules directly onto the firewall.
+It will load the rule into the running config and pass it to firewalld with the
+`--permanent` flag, to persist it after a reload.
+
+#### Examples
+
+```ruby
+# This opens the ssh service to ip `192.168.100.5` and logs at a rate of 1 entry
+# per minute with a prefix of ssh on each log entry.
+#
+
+firewalld_rich_rule "ssh_add" do
+  zone 'public'
+  family 'ipv4'
+  source_address '192.168.100.5/32'
+  service_name 'ssh'
+  log_prefix 'ssh'
+  log_level 'info'
+  limit_value '1/m'
+  firewall_action 'accept'
+  action :add
+end
+```
+
+#### Parameters
+The parameters for `rich_resource` map  directly to their commandline flag.
+More can be read here: [Complex Firewall Rules with Rich Language](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_Firewalls.html#Configuring_Complex_Firewall_Rules_with_the_Rich-Language_Syntax)
+
+- `name` - The name of the resource. This is not passed to the `firewall-cmd`.
+
+- `service-name` - Name of the service defined by `firewalld-cmd --get-services`.
+
+- `family` - IPv family. Choice of 'ipv4' or 'ipv6'. Default: 'ipv4'
+
+- `zone` - Predefined zone into which a network interface is placed.
+
+- `source_address` - Limits the origin of a connection attempt to a specific 
+  range of IPs.
+
+- `destination_address` - Limits the target of a connection attempt to a
+  specific range of IPs.
+
+- `port_number` - Can be a single integer or a port range, for example `5060-5062`.
+  The protocol can be specified. Depends on `port_protocol` parameter.
+
+- `port_protocol` - The protocol for the specified port, can be 'tcp' or 'udp'. 
+  Depends on `port_number` parameter and defaults to 'tcp'.
+
+- `log_prefix` - Logs new connection attempts with kernel logging. This will 
+  prepend the log lines with this prefix.
+
+- `log_level` - Can be one of 'emerg', 'alert', 'error', 'warning', 'notice', 
+  'info', or 'debug'.
+
+- `limit_value` - Limits the rate at which logs are written. Defaults to "1/m" 
+  one write per minute.
+
+- `firewall_action` - Can be one of 'accept', 'reject', or 'drop'. This is the 
+  behavior by which all traffic that matches the rule will be handled.
 
 Usage
 -----

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -6,4 +6,12 @@ if defined?(ChefSpec)
   def remove_firewalld_port(port)
     ChefSpec::Matchers::ResourceMatcher.new(:firewalld_port, :remove, port)
   end
+
+  def add_firewalld_rich_rule(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:firewalld_rich_rule, :add, name)
+  end
+
+  def remove_firewalld_rich_rule(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:firewalld_rich_rule, :remove, name)
+  end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jeff@jeffhutchison.com'
 license          'Apache v2.0'
 description      'Installs/Configures firewalld'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.3.0'
 
 supports         'centos', ">= 7.0"
 supports         'rhel', ">= 7.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jeff@jeffhutchison.com'
 license          'Apache v2.0'
 description      'Installs/Configures firewalld'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.2.1'
 
 supports         'centos', ">= 7.0"
 supports         'rhel', ">= 7.0"

--- a/providers/rich_rule.rb
+++ b/providers/rich_rule.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: firewalld
+# Provider:: rich_rule
+#
+# Copyright:: 2015, Jeff Hutchison
+
+action :add do
+  e = execute "add port #{new_resource.name} to zone" do
+    not_if "firewall-cmd #{zone} --query-rich-rule=\"#{rich_rule}\""
+    command(<<-EOC)
+    firewall-cmd #{zone} --add-rich-rule="#{rich_rule}"
+    firewall-cmd --permanent #{zone} --add-rich-rule="#{rich_rule}"
+    EOC
+  end
+  new_resource.updated_by_last_action(e.updated_by_last_action?)
+end
+
+action :remove do
+  e = execute "remove port #{new_resource.name} from zone" do
+    only_if "firewall-cmd #{zone} --query-rich-rule=\"#{rich_rule}\""
+    command(<<-EOC)
+    firewall-cmd #{zone} --remove-rich-rule="#{rich_rule}"
+    firewall-cmd --permanent #{zone} --remove-rich-rule="#{rich_rule}"
+    EOC
+  end
+  new_resource.updated_by_last_action(e.updated_by_last_action?)
+end
+
+def zone
+  new_resource.zone ? "--zone=#{new_resource.zone}" : ''
+end
+
+def rich_rule
+    cmd = "rule "
+    cmd += "family='#{new_resource.family}' " if new_resource.family
+    cmd += "source address='#{new_resource.source_address}' " if new_resource.source_address
+    cmd += "destination address='#{new_resource.destination_address}' " if new_resource.destination_address
+    cmd += "service name='#{new_resource.service_name}' " if new_resource.service_name
+    cmd += "port port='#{new_resource.port_number}' protocol=#{new_resource.port_protocol}" if new_resource.port_number
+    cmd += "log prefix='#{new_resource.log_prefix}' " if new_resource.log_prefix
+    cmd += "level='#{new_resource.log_level}' " if new_resource.log_level
+    cmd += "limit value='#{new_resource.limit_value}' " if new_resource.limit_value
+    cmd += "#{new_resource.firewall_action}" if new_resource.firewall_action
+    cmd
+end

--- a/resources/rich_rule.rb
+++ b/resources/rich_rule.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: firewalld
+# Provider:: rich_rule
+#
+# Copyright:: 2015, Jeff Hutchison
+
+# List of all actions supported by provider
+actions :add, :remove
+
+# Make add the default action
+default_action :add
+
+# Required attributes
+attribute :name, :kind_of => String, :name_attribute => true
+
+# Optional attributes
+attribute :service_name, :kind_of => [String, NilClass]
+attribute :family, :kind_of => String, :default => "ipv4"
+attribute :zone, :kind_of => String
+attribute :source_address, :kind_of => [String, NilClass]
+attribute :destination_address, :kind_of => [String, NilClass]
+attribute :port_number, :kind_of => [Integer, NilClass]
+attribute :port_protocol, :kind_of => [String, NilClass], :default => "tcp"
+attribute :log_prefix, :kind_of => [String, NilClass]
+attribute :log_level, :kind_of => [String, NilClass]
+attribute :limit_value, :kind_of => [String, NilClass]
+attribute :firewall_action, :kind_of => [String, NilClass]

--- a/resources/rich_rule.rb
+++ b/resources/rich_rule.rb
@@ -19,9 +19,9 @@ attribute :family, :kind_of => String, :default => "ipv4"
 attribute :zone, :kind_of => String
 attribute :source_address, :kind_of => [String, NilClass]
 attribute :destination_address, :kind_of => [String, NilClass]
-attribute :port_number, :kind_of => [Integer, NilClass]
+attribute :port_number, :kind_of => [String, NilClass]
 attribute :port_protocol, :kind_of => [String, NilClass], :default => "tcp"
 attribute :log_prefix, :kind_of => [String, NilClass]
 attribute :log_level, :kind_of => [String, NilClass]
-attribute :limit_value, :kind_of => [String, NilClass]
+attribute :limit_value, :kind_of => [String, NilClass], :default => "1/m"
 attribute :firewall_action, :kind_of => [String, NilClass]

--- a/spec/unit/rich_rule_spec.rb
+++ b/spec/unit/rich_rule_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'fixture::rich_rule' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new.converge(described_recipe)
+  end
+
+  it "enables and starts firewalld service" do
+    expect(chef_run).to enable_service('firewalld')
+    expect(chef_run).to start_service('firewalld')
+  end
+
+  it "adds rule for ssh" do
+    expect(chef_run).to add_firewalld_rich_rule("ssh add")
+  end
+
+  it "removes rule for ssh" do
+    expect(chef_run).to remove_firewalld_rich_rule("ssh remove")
+  end
+
+end

--- a/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
+++ b/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
@@ -1,0 +1,45 @@
+service 'firewalld' do
+  action [:enable, :start]
+end
+
+firewalld_rich_rule "ssh add" do
+  zone 'public'
+  family 'ipv4'
+  source_address '192.168.100.0/22'
+  service_name 'ssh'
+  log_prefix 'ssh'
+  log_level 'info'
+  limit_value '1/m'
+  firewall_action 'accept'
+  action :add
+end
+
+rules = [
+  'rule family="ipv4" source address="192.168.200.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept',
+  'rule family="ipv4" source address="192.168.254.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept',
+]
+
+rules.each do |r|
+  execute "add #{r}" do
+    command(<<-EOC)
+    firewall-cmd --zone=public --add-rich-rule='#{r}'
+    firewall-cmd --zone=public --add-rich-rule='#{r}' --permanent
+    EOC
+  end
+end
+
+firewalld_rich_rule "ssh remove" do
+  zone 'public'
+  family 'ipv4'
+  service_name 'ssh'
+  source_address '192.168.254.0/22'
+  log_prefix 'ssh'
+  log_level 'info'
+  limit_value '1/m'
+  firewall_action 'accept'
+  action :remove
+end
+
+
+# Services
+# amanda-client bacula bacula-client dhcp dhcpv6 dhcpv6-client dns ftp high-availability http https imaps ipp ipp-client ipsec kerberos kpasswd ldap ldaps libvirt libvirt-tls mdns mountd ms-wbt mysql nfs ntp openvpn pmcd pmproxy pmwebapi pmwebapis pop3s postgresql proxy-dhcp radius rpc-bind samba samba-client smtp ssh telnet tftp tftp-client transmission-client vnc-server wbem-https

--- a/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
+++ b/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
@@ -39,7 +39,3 @@ firewalld_rich_rule "ssh remove" do
   firewall_action 'accept'
   action :remove
 end
-
-
-# Services
-# amanda-client bacula bacula-client dhcp dhcpv6 dhcpv6-client dns ftp high-availability http https imaps ipp ipp-client ipsec kerberos kpasswd ldap ldaps libvirt libvirt-tls mdns mountd ms-wbt mysql nfs ntp openvpn pmcd pmproxy pmwebapi pmwebapis pop3s postgresql proxy-dhcp radius rpc-bind samba samba-client smtp ssh telnet tftp tftp-client transmission-client vnc-server wbem-https

--- a/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
+++ b/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
@@ -5,7 +5,7 @@ end
 firewalld_rich_rule "ssh add" do
   zone 'public'
   family 'ipv4'
-  source_address '192.168.100.0/22'
+  source_address '192.168.100.0/24'
   service_name 'ssh'
   log_prefix 'ssh'
   log_level 'info'
@@ -15,8 +15,8 @@ firewalld_rich_rule "ssh add" do
 end
 
 rules = [
-  'rule family="ipv4" source address="192.168.200.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept',
-  'rule family="ipv4" source address="192.168.254.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept',
+  'rule family="ipv4" source address="192.168.200.0/24" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept',
+  'rule family="ipv4" source address="192.168.254.0/24" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept',
 ]
 
 rules.each do |r|
@@ -32,7 +32,7 @@ firewalld_rich_rule "ssh remove" do
   zone 'public'
   family 'ipv4'
   service_name 'ssh'
-  source_address '192.168.254.0/22'
+  source_address '192.168.254.0/24'
   log_prefix 'ssh'
   log_level 'info'
   limit_value '1/m'

--- a/test/integration/rich_rule/bats/default.bats
+++ b/test/integration/rich_rule/bats/default.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+rule1='rule family="ipv4" source address="192.168.100.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
+rule2='rule family="ipv4" source address="192.168.200.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
+rule3='rule family="ipv4" source address="192.168.254.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
+
+@test "rule 1 was added to permanent config" {
+        run bash -c "firewall-cmd --permanent --query-rich-rule='${rule1}'"
+        [ "$status" -eq 0 ]
+}
+
+@test "rule 1 was added to runtime config" {
+        run bash -c "firewall-cmd --query-rich-rule='${rule1}'"
+        [ "$status" -eq 0 ]
+}
+
+@test "rule 3 was removed from runtime config" {
+        run bash -c "firewall-cmd --query-rich-rule='${rule3}'"
+        [ "$status" -eq 1 ]
+}
+
+@test "rule 3 was removed from permanent config" {
+        run bash -c "firewall-cmd --permanent --query-rich-rule='${rule3}'"
+        [ "$status" -eq 1 ]
+}
+
+@test "rule 2 was not removed from runtime config" {
+        run bash -c "firewall-cmd --query-rich-rule='${rule2}'"
+        [ "$status" -eq 0 ]
+}
+
+@test "rule 2 was not removed from permanent config" {
+        run bash -c "firewall-cmd --permanent --query-rich-rule='${rule2}'"
+        [ "$status" -eq 0 ]
+}

--- a/test/integration/rich_rule/bats/default.bats
+++ b/test/integration/rich_rule/bats/default.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
-rule1='rule family="ipv4" source address="192.168.100.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
-rule2='rule family="ipv4" source address="192.168.200.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
-rule3='rule family="ipv4" source address="192.168.254.0/22" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
+rule1='rule family="ipv4" source address="192.168.100.0/24" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
+rule2='rule family="ipv4" source address="192.168.200.0/24" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
+rule3='rule family="ipv4" source address="192.168.254.0/24" service name="ssh" log prefix="ssh" level="info" limit value="1/m" accept'
 
 @test "rule 1 was added to permanent config" {
         run bash -c "firewall-cmd --permanent --query-rich-rule='${rule1}'"


### PR DESCRIPTION
Lets the end user create complex rules and have Chef pass them to firewalld. This does not validate rules but the chef run will fail if `firewall-cmd` does not return a proper status code. It is expected that the end user will have some familiarity with firewalld.
### New
- Add Rich Rule LWRP documentation to README. [Manny Toledo]
- ChefSpec test added for Rich Rule LWRP. [Manny Toledo]
- Integration tests added for Rich Rule LWRP. [Manny Toledo]
- Add rules directly with Rich Rule LWRP! [Manny Toledo]
### Fix
- Correct IPs in tests to more common ranges. [Manny Toledo]
- Update readme. [Manny Toledo]
- Add missing defaults in resource file and clean up comment. [Manny Toledo]
