### PR TITLE
Feature/onoff

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,9 @@ require 'bundler/setup'
 namespace :style do
   require 'foodcritic'
   desc 'Run Chef style checks'
-  FoodCritic::Rake::LintTask.new(:chef)
+  FoodCritic::Rake::LintTask.new(:chef) do |t|
+    t.options = { tags: %w(~FC001) }
+  end
 end
 
 require 'rspec/core/rake_task'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default[:firewalld][:iptables_fallback] = true

--- a/providers/rich_rule.rb
+++ b/providers/rich_rule.rb
@@ -40,6 +40,6 @@ def rich_rule
     cmd += "log prefix='#{new_resource.log_prefix}' " if new_resource.log_prefix
     cmd += "level='#{new_resource.log_level}' " if new_resource.log_level
     cmd += "limit value='#{new_resource.limit_value}' " if new_resource.limit_value
-    cmd += "#{new_resource.firewall_action}" if new_resource.firewall_action
+    cmd += "#{new_resource.firewall_action}" if new_resource.firewall_action # ~FC002
     cmd
 end

--- a/recipes/disable.rb
+++ b/recipes/disable.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: firewalld
+# Recipe:: disable
+#
+
+package 'iptables-services'
+
+service 'firewalld' do
+  action [:disable, :stop]
+end
+
+service 'iptables' do
+  action [:enable, :start]
+  only_if { node[:firewalld][:iptables_fallback] }
+end
+
+service 'ip6tables' do
+  action [:enable, :start]
+  only_if { node[:firewalld][:iptables_fallback] }
+end
+
+

--- a/recipes/enable.rb
+++ b/recipes/enable.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: firewalld
+# Recipe:: enable
+#
+
+package 'firewalld'
+
+service 'firewalld' do
+  action [:enable, :start]
+end
+
+service 'iptables' do
+  action [:disable, :stop]
+  only_if { node[:firewalld][:iptables_fallback] }
+end
+
+service 'ip6tables' do
+  action [:disable, :stop]
+  only_if { node[:firewalld][:iptables_fallback] }
+end
+
+


### PR DESCRIPTION
In some environments I need to explicitly disable firewalld in favor of iptables services. The `enable` recipe should be used when migration to firewalld is possible.
