### PR TITLE
Correct the spacing in the rich rule lwrp

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jeff@jeffhutchison.com'
 license          'Apache v2.0'
 description      'Installs/Configures firewalld'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.1.1'
 
 supports         'fedora', ">= 15.0"
 supports         'centos', ">= 7.0"

--- a/providers/rich_rule.rb
+++ b/providers/rich_rule.rb
@@ -36,7 +36,7 @@ def rich_rule
     cmd += "source address='#{new_resource.source_address}' " if new_resource.source_address
     cmd += "destination address='#{new_resource.destination_address}' " if new_resource.destination_address
     cmd += "service name='#{new_resource.service_name}' " if new_resource.service_name
-    cmd += "port port='#{new_resource.port_number}' protocol=#{new_resource.port_protocol}" if new_resource.port_number
+    cmd += "port port='#{new_resource.port_number}' protocol=#{new_resource.port_protocol} " if new_resource.port_number
     cmd += "log prefix='#{new_resource.log_prefix}' " if new_resource.log_prefix
     cmd += "level='#{new_resource.log_level}' " if new_resource.log_level
     cmd += "limit value='#{new_resource.limit_value}' " if new_resource.limit_value


### PR DESCRIPTION
Currently the port_protocol field collides with the log field. This PR adds a space in between.
