### PR TITLE
add Ubuntu/Debian support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
 
 platforms:
   - name: centos-7.0
+  - name: ubuntu-14.04
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
 name             'firewalld'
 maintainer       'Jeff Hutchison'
 maintainer_email 'jeff@jeffhutchison.com'
+source_url       'https://github.com/jhh/firewalld-cookbook'
 license          'Apache v2.0'
 description      'Installs/Configures firewalld'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
@@ -8,4 +9,6 @@ version          '1.1.0'
 
 supports         'fedora', ">= 15.0"
 supports         'centos', ">= 7.0"
-supports         'rhel', ">= 7.0"
+supports         'rhel',   ">= 7.0"
+supports         'ubuntu', ">= 14.04"
+supports         'debian', ">= 8.0" # untested

--- a/spec/unit/port_spec.rb
+++ b/spec/unit/port_spec.rb
@@ -24,6 +24,10 @@ describe 'fixture::port' do
     ChefSpec::SoloRunner.new.converge(described_recipe)
   end
 
+  it "installs firewalld" do
+    expect(chef_run).to install_package("firewalld")
+  end
+
   it "adds port 993/tcp" do
     expect(chef_run).to add_firewalld_port("993/tcp")
   end

--- a/test/fixtures/cookbooks/fixture/recipes/port.rb
+++ b/test/fixtures/cookbooks/fixture/recipes/port.rb
@@ -1,3 +1,5 @@
+package 'firewalld'
+
 service 'firewalld' do
   action [:enable, :start]
 end

--- a/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
+++ b/test/fixtures/cookbooks/fixture/recipes/rich_rule.rb
@@ -1,3 +1,5 @@
+package 'firewalld'
+
 service 'firewalld' do
   action [:enable, :start]
 end


### PR DESCRIPTION
Fixes #10 

Turns out the cookbooks works with Ubuntu 14.04 out of the box. Had to adjust the fixture cookbook, as it's not a default installed package.

I could not test Debian 8, because Chef has not released a Bento box yet due to difficulties with virtualization providers, but I'm confident, that it also works on Debian 8.
