### PR TITLE
fixed rich rule log prefix item - now adds 'log '

### DIFF
--- a/providers/rich_rule.rb
+++ b/providers/rich_rule.rb
@@ -37,7 +37,8 @@ def rich_rule
     cmd += "destination address='#{new_resource.destination_address}' " if new_resource.destination_address
     cmd += "service name='#{new_resource.service_name}' " if new_resource.service_name
     cmd += "port port='#{new_resource.port_number}' protocol='#{new_resource.port_protocol}' " if new_resource.port_number
-    cmd += "log prefix='#{new_resource.log_prefix}' " if new_resource.log_prefix
+    cmd += "log " if new_resource.log_prefix || new_resource.log_level || new_resource.limit_value
+    cmd += "prefix='#{new_resource.log_prefix}' " if new_resource.log_prefix
     cmd += "level='#{new_resource.log_level}' " if new_resource.log_level
     cmd += "limit value='#{new_resource.limit_value}' " if new_resource.limit_value
     cmd += new_resource.firewall_action if new_resource.firewall_action


### PR DESCRIPTION
if new_resource.log_prefix, new_resource.log_level
or new_resource.limit_value is present to match the
documentation

note: this does not fix the issue where limit could be
used to specify match limits, it only brings
the recipe in-line with its own documentation
