### PR TITLE
Port numbers are usually integers

### DIFF
--- a/resources/rich_rule.rb
+++ b/resources/rich_rule.rb
@@ -19,7 +19,7 @@ attribute :family, :kind_of => String, :default => "ipv4"
 attribute :zone, :kind_of => String
 attribute :source_address, :kind_of => [String, NilClass]
 attribute :destination_address, :kind_of => [String, NilClass]
-attribute :port_number, :kind_of => [String, NilClass]
+attribute :port_number, :kind_of => [Integer, NilClass]
 attribute :port_protocol, :kind_of => [String, NilClass], :default => "tcp"
 attribute :log_prefix, :kind_of => [String, NilClass]
 attribute :log_level, :kind_of => [String, NilClass]


### PR DESCRIPTION
Getting a syntax error because of this resource being a string instead of an integer